### PR TITLE
#curl_error must be called before #curl_close

### DIFF
--- a/resources/server/libraries.php
+++ b/resources/server/libraries.php
@@ -87,10 +87,10 @@
       curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
       curl_setopt($ch, CURLOPT_USERAGENT, 'The SkinSystem');
       $response = curl_exec($ch);
-      curl_close($ch);
       if($response === false){
         printErrorAndDie(str_replace("%err%", curl_error($ch), L::gnrl_crlerr));
       }
+      curl_close($ch);
       return($response);
     } else {
       return(file_get_contents($url));


### PR DESCRIPTION
Belong to this question https://stackoverflow.com/questions/19442999/getting-curl-error-2-is-not-a-valid-curl-handle-resource-while-fetching-all-u

**The issue from this [discord user](https://discordapp.com/channels/186794372468178944/474606828924436481/692722814205296690)**